### PR TITLE
Fix only includes `dist` folder in pkg

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,5 +26,8 @@
     "date-fns": "^2.29.3",
     "echarts": "^5.4.1",
     "wait-port": "^1.0.4"
-  }
+  },
+  "files": [
+    "dist"
+  ]
 }


### PR DESCRIPTION
This pull request resolves an issue where only the dist folder was being included in the pkg package. The change ensures that all necessary files are properly included in the package.